### PR TITLE
Contracts: Improve wallet tests and coverage

### DIFF
--- a/apps/contracts/contracts/test/Reverter.sol
+++ b/apps/contracts/contracts/test/Reverter.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.0;
 
-contract Revert {
+contract Reverter {
   function fail() external pure {
     revert("REVERTED");
   }

--- a/apps/contracts/contracts/test/mocks/EntryPointMock.sol
+++ b/apps/contracts/contracts/test/mocks/EntryPointMock.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "../../ERC4337/Wallet.sol";
+
+import {PostOpMode} from "../../ERC4337/interface/IPaymaster.sol";
+import {UserOperation} from "../../ERC4337/library/UserOperation.sol";
+
+contract EntryPointMock {
+  Wallet public wallet;
+  bool public revertOnReceive;
+
+  function setWallet(Wallet _wallet) external {
+    wallet = _wallet;
+  }
+
+  function mockReceiveRevert(bool fail) external {
+    revertOnReceive = fail;
+  }
+
+  function validateUserOp(
+    UserOperation calldata op,
+    bytes32 requestId,
+    uint256 requiredPrefund
+  ) external {
+    wallet.validateUserOp(op, requestId, requiredPrefund);
+  }
+
+  function executeUserOp(
+    address to,
+    uint256 value,
+    bytes calldata data
+  ) external {
+    wallet.executeUserOp(to, value, data);
+  }
+
+  function postOp(
+    PostOpMode mode,
+    bytes calldata context,
+    uint256 actualGasCost
+  ) external {
+    wallet.postOp(mode, context, actualGasCost);
+  }
+
+  function transferOwner(address to) external {
+    wallet.transferOwner(to);
+  }
+
+  function grantGuardian(address to) external {
+    wallet.grantGuardian(to);
+  }
+
+  function revokeGuardian(address to) external {
+    wallet.revokeGuardian(to);
+  }
+
+  function upgradeTo(address implementation) external {
+    wallet.upgradeTo(implementation);
+  }
+
+  receive() external payable {
+    require(!revertOnReceive, "ENTRY_POINT_RECEIVE_FAILED");
+  }
+}

--- a/apps/contracts/test/utils/helpers/numbers.ts
+++ b/apps/contracts/test/utils/helpers/numbers.ts
@@ -5,6 +5,8 @@ const SCALING_FACTOR = 1e18
 
 export type BigNumberish = string | number | BigNumber
 
+export const isBigNumberish = (x: any) => BigNumber.isBigNumber(x) || typeof x === 'number'
+
 export const decimal = (x: BigNumberish | Decimal): Decimal => new Decimal(x.toString())
 
 export const pct = (x: BigNumberish, pct: BigNumberish): BigNumber => bn(decimal(x).mul(decimal(pct)))

--- a/apps/contracts/test/utils/helpers/signers.ts
+++ b/apps/contracts/test/utils/helpers/signers.ts
@@ -11,7 +11,7 @@ export async function getSigner(indexOrAddress: number | string = 0): Promise<Si
   }
 }
 
-export async function getSigners(size?: number): Promise<SignerWithAddress[]> {
+export async function getSigners(size?: number, offset = 0): Promise<SignerWithAddress[]> {
   const signers = await ethers.getSigners()
-  return size ? signers.slice(0, size) : signers
+  return size ? signers.slice(offset, offset + size) : signers
 }

--- a/apps/contracts/test/utils/models/entry-point/EntryPoint.ts
+++ b/apps/contracts/test/utils/models/entry-point/EntryPoint.ts
@@ -1,5 +1,6 @@
 import { ethers } from 'hardhat'
 import { BigNumber, Contract, ContractTransaction } from 'ethers'
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
 
 import EntryPointDeployer from './EntryPointDeployer'
 
@@ -7,7 +8,7 @@ import { bn } from '../../helpers/numbers'
 import { UserOp } from '../user/types'
 import { ZERO_ADDRESS } from '../../helpers/constants'
 import { encodeRequestId, encodeWalletValidateOp } from '../../helpers/encoding'
-import {Account, NAry, TxParams, toArray, toBytes32, toAddress} from '../../types'
+import { Account, NAry, TxParams, toArray, toBytes32, toAddress } from '../../types'
 
 export default class EntryPoint {
   instance: Contract
@@ -85,6 +86,6 @@ export default class EntryPoint {
   }
 
   with(params: TxParams = {}): Contract {
-    return params.from ? this.instance.connect(params.from) : this.instance
+    return params.from ? this.instance.connect(params.from as SignerWithAddress) : this.instance
   }
 }

--- a/apps/contracts/test/utils/models/user/User.ts
+++ b/apps/contracts/test/utils/models/user/User.ts
@@ -8,11 +8,14 @@ import { getSigners } from '../../helpers/signers'
 import { ZERO_ADDRESS } from '../../helpers/constants'
 import { deploy, instanceAt } from '../../helpers/contracts'
 import { assertIndirectEvent } from '../../helpers/asserts'
+import { encodeSignatures, encodeWalletExecute, encodeWalletDeployment, encodeCounterIncrement } from '../../helpers/encoding'
+
 import { Account, toAddress } from '../../types'
 import { UserOp, UserOpParams } from './types'
-import { encodeCounterIncrement, encodeOwnerSignature, encodeWalletDeployment, encodeWalletExecute } from '../../helpers/encoding'
+
 
 export default class User {
+  static OWNER_SIGNATURE = 0
   static WALLET_CREATION_GAS = bn(690e3)
   static WALLET_VERIFICATION_GAS = bn(38500)
   static COUNTER_CALL_WITH_VALUE_GAS = bn(35000)
@@ -64,7 +67,7 @@ export default class User {
   async signOp(op: UserOp): Promise<string> {
     const requestId = await this.entryPoint.getRequestId(op)
     const signature = await this.signer.signMessage(ethers.utils.arrayify(requestId))
-    return encodeOwnerSignature({ signer: toAddress(this.signer), signature })
+    return encodeSignatures(User.OWNER_SIGNATURE, { signer: toAddress(this.signer), signature })
   }
 
   async getWalletDeploymentCode(implementation?: Contract): Promise<string> {

--- a/apps/contracts/test/utils/models/user/types.ts
+++ b/apps/contracts/test/utils/models/user/types.ts
@@ -1,5 +1,8 @@
 import { BigNumber } from 'ethers'
+
+import { bn } from '../../helpers/numbers'
 import { BigNumberish } from '../../types'
+import { ZERO_ADDRESS } from '../../helpers/constants'
 
 export type Signature = {
   signer: string;
@@ -34,4 +37,21 @@ export type UserOpParams = {
   paymaster?: string;
   paymasterData?: string;
   signature?: string;
+}
+
+export function buildOp(params?: UserOpParams): UserOp {
+  return {
+    sender: params?.sender ?? ZERO_ADDRESS,
+    nonce: params?.nonce ?? 0,
+    initCode: params?.initCode ?? '0x',
+    callData: params?.callData ?? '0x',
+    callGas: params?.callGas ?? bn(0),
+    verificationGas: params?.verificationGas ?? bn(0),
+    preVerificationGas: params?.preVerificationGas ?? bn(0),
+    maxFeePerGas: params?.maxFeePerGas ?? bn(0),
+    maxPriorityFeePerGas: params?.maxPriorityFeePerGas ?? bn(0),
+    paymaster: params?.paymaster ?? ZERO_ADDRESS,
+    paymasterData: params?.paymasterData ?? '0x',
+    signature: params?.signature ?? '0x',
+  }
 }

--- a/apps/contracts/test/utils/models/wallet/Wallet.ts
+++ b/apps/contracts/test/utils/models/wallet/Wallet.ts
@@ -1,0 +1,138 @@
+import {ethers} from 'hardhat'
+import {BigNumber, Contract, ContractTransaction} from 'ethers'
+import {SignerWithAddress} from '@nomiclabs/hardhat-ethers/signers'
+
+import WalletDeployer from './WalletDeployer'
+import {ZERO_BYTES32} from '../../helpers/constants'
+import {encodeRequestId, encodeSignatures} from '../../helpers/encoding'
+
+import {UserOp} from '../user/types'
+import {WalletDeployParams} from './types'
+import {Account, BigNumberish, toAddress, TxParams} from '../../types'
+import {isBigNumberish} from "../../helpers/numbers";
+
+export default class Wallet {
+  static OWNER_SIGNATURE = 0
+  static GUARDIANS_SIGNATURE = 1
+
+  instance: Contract
+  implementation: Contract
+  entryPoint: Contract
+  owner: SignerWithAddress
+  guardians: SignerWithAddress[]
+
+  static async create(params: WalletDeployParams = {}): Promise<Wallet> {
+    return WalletDeployer.deploy(params)
+  }
+
+  constructor(instance: Contract, implementation: Contract, entryPoint: Contract, owner: SignerWithAddress, guardians: SignerWithAddress[]) {
+    this.instance = instance
+    this.implementation = implementation
+    this.entryPoint = entryPoint
+    this.owner = owner
+    this.guardians = guardians
+  }
+
+  get address(): string {
+    return this.instance.address
+  }
+
+  async getCurrentImplementation(): Promise<string> {
+    return this.instance.getCurrentImplementation()
+  }
+
+  async nonce(): Promise<BigNumber> {
+    return this.instance.nonce()
+  }
+
+  async getRequestId(op: UserOp): Promise<string> {
+    const network = await this.instance.provider!.getNetwork()
+    return encodeRequestId(op, this.entryPoint, network.chainId)
+  }
+
+  async getOwnerCount(): Promise<BigNumber> {
+    return this.instance.getOwnerCount()
+  }
+
+  async getGuardianCount(): Promise<BigNumber> {
+    return this.instance.getGuardianCount()
+  }
+
+  async getOwner(index: number): Promise<string> {
+    return this.instance.getOwner(index)
+  }
+
+  async getGuardian(index: number): Promise<string> {
+    return this.instance.getGuardian(index)
+  }
+
+  async getRoleMemberCount(role: string): Promise<BigNumber> {
+    return this.instance.getRoleMemberCount(role)
+  }
+
+  async getRoleAdmin(role: string): Promise<string> {
+    return this.instance.getRoleAdmin(role)
+  }
+
+  async hasRole(role: string, account: Account): Promise<boolean> {
+    return this.instance.hasRole(role, toAddress(account))
+  }
+
+  async isValidSignature(message: string, signature: string): Promise<string> {
+    return this.instance.isValidSignature(message, signature)
+  }
+
+  async signWithOwner(op: UserOp, requestId: string): Promise<string> {
+    const signature = await this.owner.signMessage(ethers.utils.arrayify(requestId))
+    return encodeSignatures(Wallet.OWNER_SIGNATURE, { signer: this.owner.address, signature })
+  }
+
+  async signWithGuardians(op: UserOp, requestId: string): Promise<string> {
+    return encodeSignatures(Wallet.GUARDIANS_SIGNATURE, await Promise.all(this.guardians.map(async guardian => {
+      return { signer: guardian.address, signature: await guardian.signMessage(ethers.utils.arrayify(requestId)) }
+    })))
+  }
+
+  async validatePaymasterUserOp(op: UserOp, maxCost: BigNumberish = 0): Promise<string> {
+    return this.instance.validatePaymasterUserOp(op, maxCost)
+  }
+
+  async validateUserOp(op: UserOp, requestId = ZERO_BYTES32, prefundOrParams: BigNumberish | TxParams = 0, params: TxParams = {}): Promise<ContractTransaction> {
+    const prefund = isBigNumberish(prefundOrParams) ? prefundOrParams.toString() : 0
+    params = (isBigNumberish(prefundOrParams) ? params : prefundOrParams) as TxParams
+    return this.with(params).validateUserOp(op, requestId, prefund)
+  }
+
+  async executeUserOp(to: Account, data = '0x', valueOrParams: BigNumberish | TxParams = 0, params: TxParams = {}): Promise<ContractTransaction> {
+    const value = isBigNumberish(valueOrParams) ? valueOrParams.toString() : 0
+    params = (isBigNumberish(valueOrParams) ? params : valueOrParams) as TxParams
+    return this.with(params).executeUserOp(toAddress(to), value, data)
+  }
+
+  async postOp(context: string, actualGasCost: BigNumberish, modeOrParams: BigNumberish | TxParams = 0, params: TxParams = {}): Promise<ContractTransaction> {
+    const mode = isBigNumberish(modeOrParams) ? modeOrParams.toString() : 0
+    params = (isBigNumberish(modeOrParams) ? params : modeOrParams) as TxParams
+    return this.with(params).postOp(mode, context, actualGasCost)
+  }
+
+  async transferOwner(to: Account, params: TxParams = {}): Promise<ContractTransaction> {
+    return this.with(params).transferOwner(toAddress(to))
+  }
+
+  async grantGuardian(to: Account, params: TxParams = {}): Promise<ContractTransaction> {
+    return this.with(params).grantGuardian(toAddress(to))
+  }
+
+  async revokeGuardian(to: Account, params: TxParams = {}): Promise<ContractTransaction> {
+    return this.with(params).revokeGuardian(toAddress(to))
+  }
+
+  async upgradeTo(implementation: Contract, params: TxParams = {}): Promise<ContractTransaction> {
+    return this.with(params).upgradeTo(toAddress(implementation))
+  }
+
+  with(params: TxParams = {}): Contract {
+    if (params.from === this.entryPoint) return this.entryPoint
+    return params.from ? this.instance.connect(params.from as SignerWithAddress) : this.instance
+  }
+}

--- a/apps/contracts/test/utils/models/wallet/WalletDeployer.ts
+++ b/apps/contracts/test/utils/models/wallet/WalletDeployer.ts
@@ -1,0 +1,22 @@
+import Wallet from './Wallet'
+import { WalletDeployParams } from './types'
+
+import { getSigner } from '../../helpers/signers'
+import { encodeWalletInit } from '../../helpers/encoding'
+import { deploy, instanceAt } from '../../helpers/contracts'
+
+const WalletDeployer = {
+  async deploy(params: WalletDeployParams): Promise<Wallet> {
+    const entryPoint = params.entryPoint ?? (await deploy('EntryPointMock'))
+    const implementation = await deploy('Wallet')
+    const owner = params.owner ?? await getSigner()
+    const initialization = await encodeWalletInit(entryPoint, owner, params.guardians)
+
+    const proxy = await deploy('WalletProxy', [implementation.address, initialization])
+    const instance = await instanceAt('Wallet', proxy.address)
+    await entryPoint.setWallet(instance.address)
+    return new Wallet(instance, implementation, entryPoint, owner, params.guardians || [])
+  }
+}
+
+export default WalletDeployer

--- a/apps/contracts/test/utils/models/wallet/types.ts
+++ b/apps/contracts/test/utils/models/wallet/types.ts
@@ -1,0 +1,8 @@
+import { Contract } from 'ethers'
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
+
+export type WalletDeployParams = {
+  owner?: SignerWithAddress
+  guardians?: SignerWithAddress[]
+  entryPoint?: Contract
+}

--- a/apps/contracts/test/utils/types.ts
+++ b/apps/contracts/test/utils/types.ts
@@ -2,6 +2,8 @@ import { ethers } from 'hardhat'
 import { BigNumber } from 'ethers'
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
 
+import { ZERO_ADDRESS } from './helpers/constants'
+
 export type NAry<T> = T | Array<T>
 
 export type BigNumberish = string | number | BigNumber
@@ -9,10 +11,11 @@ export type BigNumberish = string | number | BigNumber
 export type Account = string | { address: string }
 
 export type TxParams = {
-  from?: SignerWithAddress
+  from?: Account
 }
 
-export function toAddress(account: Account): string {
+export function toAddress(account?: Account): string {
+  if (!account) return ZERO_ADDRESS
   return typeof account === 'string' ? account : account.address
 }
 


### PR DESCRIPTION
The idea of this PR was to follow the similar strategy we did in #344 but for the Wallet and Paymaster contracts.
Here I focused on unit tests instead, to avoid coupling these tests too much with the EntryPoint logic. The idea is to separate the current EntryPoint tests into unit and integration tests as well.

Some issues were found during testing, and this should be fixed from now on.