### PR TITLE
Remove IPFS logos and fix decimals

### DIFF
--- a/apps/backend/src/config/tokenList.js
+++ b/apps/backend/src/config/tokenList.js
@@ -308,7 +308,7 @@ const tokenList = {
       symbol: 'UNI',
       decimals: 18,
       chainId: 1,
-      logoURI: 'ipfs://QmXttGpZrECX5qCyXbBQiqgQNytVGeZW5Anewvh2jc4psg',
+      logoURI: 'https://cryptologos.cc/logos/uniswap-uni-logo.png',
     },
     {
       name: 'USDCoin',
@@ -378,7 +378,7 @@ const tokenList = {
       symbol: 'UNI',
       decimals: 18,
       chainId: 3,
-      logoURI: 'ipfs://QmXttGpZrECX5qCyXbBQiqgQNytVGeZW5Anewvh2jc4psg',
+      logoURI: 'https://cryptologos.cc/logos/uniswap-uni-logo.png',
     },
     {
       name: 'Wrapped Ether',
@@ -413,7 +413,7 @@ const tokenList = {
       symbol: 'UNI',
       decimals: 18,
       chainId: 4,
-      logoURI: 'ipfs://QmXttGpZrECX5qCyXbBQiqgQNytVGeZW5Anewvh2jc4psg',
+      logoURI: 'https://cryptologos.cc/logos/uniswap-uni-logo.png',
     },
     {
       name: 'Wrapped Ether',
@@ -430,7 +430,7 @@ const tokenList = {
       symbol: 'UNI',
       decimals: 18,
       chainId: 5,
-      logoURI: 'ipfs://QmXttGpZrECX5qCyXbBQiqgQNytVGeZW5Anewvh2jc4psg',
+      logoURI: 'https://cryptologos.cc/logos/uniswap-uni-logo.png',
     },
     {
       name: 'Wrapped Ether',
@@ -465,7 +465,7 @@ const tokenList = {
       symbol: 'UNI',
       decimals: 18,
       chainId: 42,
-      logoURI: 'ipfs://QmXttGpZrECX5qCyXbBQiqgQNytVGeZW5Anewvh2jc4psg',
+      logoURI: 'https://cryptologos.cc/logos/uniswap-uni-logo.png',
     },
     {
       name: 'Wrapped Ether',
@@ -724,7 +724,7 @@ const tokenList = {
       symbol: 'UNI',
       decimals: 18,
       chainId: 137,
-      logoURI: 'ipfs://QmXttGpZrECX5qCyXbBQiqgQNytVGeZW5Anewvh2jc4psg',
+      logoURI: 'https://cryptologos.cc/logos/uniswap-uni-logo.png',
     },
     {
       name: 'USDCoin',

--- a/apps/web/src/components/tokenCard.js
+++ b/apps/web/src/components/tokenCard.js
@@ -8,7 +8,7 @@ export const TokenCard = ({
   name,
   logo,
   valueWei,
-  decimal,
+  decimals,
   symbol,
   valueUsdc,
   onClick = () => {},
@@ -41,7 +41,7 @@ export const TokenCard = ({
         <VStack spacing="2px" alignItems="end">
           <Skeleton isLoaded={!isLoading}>
             <Text fontSize="sm" textAlign="right" fontWeight="bold">
-              {displayGenericToken(valueWei, decimal, symbol)}
+              {displayGenericToken(valueWei, decimals, symbol)}
             </Text>
           </Skeleton>
 

--- a/apps/web/src/utils/web3.js
+++ b/apps/web/src/utils/web3.js
@@ -40,7 +40,9 @@ export const displayUSDC = (balance) => {
 };
 
 export const displayGenericToken = (value, decimal, symbol) => {
-  return `${ethers.utils.formatUnits(ethers.BigNumber.from(value), decimal)} ${symbol}`;
+  return `${ethers.utils.commify(
+    ethers.utils.formatUnits(ethers.BigNumber.from(value), decimal),
+  )} ${symbol}`;
 };
 
 export const signatureCount = (userOp) => {


### PR DESCRIPTION
Spotted a couple bugs in mainnet.

1. We currently don't support IPFS logos so switched to a `.png` link
2. Decimal not rendering properly