### PR TITLE
Contracts: Fix paymaster token fee calc

### DIFF
--- a/apps/contracts/contracts/test/samples/TokenMock.sol
+++ b/apps/contracts/contracts/test/samples/TokenMock.sol
@@ -5,8 +5,14 @@ pragma solidity ^0.8.0;
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 contract TokenMock is ERC20 {
-  constructor(string memory symbol) ERC20(symbol, symbol) {
-    // solhint-disable-previous-line no-empty-blocks
+  uint8 internal _decimals;
+
+  constructor(string memory symbol, uint8 decimals_) ERC20(symbol, symbol) {
+    _decimals = decimals_;
+  }
+
+  function decimals() public view override returns (uint8) {
+    return _decimals;
   }
 
   function mint(address account, uint256 amount) external {

--- a/apps/contracts/scripts/benchmark/benchmark-gas.ts
+++ b/apps/contracts/scripts/benchmark/benchmark-gas.ts
@@ -85,7 +85,7 @@ async function withPaymaster(entryPoint: Contract): Promise<void> {
 
   const fee = bn(100000)
   const exchangeRate = fp(2)
-  const token = await deploy('TokenMock', ['USDC'])
+  const token = await deploy('TokenMock', ['USDC', 6])
   const feed = await deploy('PriceFeedMock', [18, exchangeRate])
   const paymaster = await createPaymaster(entryPoint, paymasterOwner)
 

--- a/apps/contracts/test/Paymaster.test.ts
+++ b/apps/contracts/test/Paymaster.test.ts
@@ -1,0 +1,121 @@
+import { expect } from 'chai'
+import { ethers } from 'hardhat'
+import { Contract } from 'ethers'
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
+
+import { deploy } from './utils/helpers/contracts'
+import { getSigner } from './utils/helpers/signers'
+import { MAX_UINT256 } from './utils/helpers/constants'
+import { bn, decimal, fp } from './utils/helpers/numbers'
+import { encodePaymasterData, encodePaymasterSignature } from './utils/helpers/encoding'
+
+import Wallet from './utils/models/wallet/Wallet'
+import { buildOp } from './utils/types'
+
+describe('Paymaster', () => {
+  let paymaster: Wallet, owner: SignerWithAddress
+
+  beforeEach('deploy paymaster', async () => {
+    owner = await getSigner()
+    paymaster = await Wallet.create({ owner })
+  })
+
+  describe('getTokenFee', () => {
+    const COST = fp(1)
+    const FEE = decimal(3)
+    const RATE = decimal(2)
+
+    const itExpressTheRateCorrectly = (tokenDecimals: number, feedDecimals: number) => {
+      let token: Contract, feed: Contract
+
+      beforeEach('deploy token and feed', async () => {
+        token = await deploy('TokenMock', ['TKN', tokenDecimals])
+        feed = await deploy('PriceFeedMock', [feedDecimals, bn(RATE.mul(10**feedDecimals))])
+      })
+
+      it(`expresses token rate with ${tokenDecimals} decimals`, async () => {
+        // pre-approve tokens since paymaster validation will check that
+        const op = buildOp({ sender: owner.address, paymaster: paymaster.address, callData: '0xabcdef1111' })
+        await token.connect(owner).approve(paymaster.address, MAX_UINT256)
+
+        const baseFee = bn(FEE.mul(10**tokenDecimals))
+        const data = encodePaymasterData(op, baseFee, token, feed)
+        const signature = await owner.signMessage(ethers.utils.arrayify((data)))
+        op.paymasterData = encodePaymasterSignature(baseFee, token, feed, signature)
+
+        const context = await paymaster.validatePaymasterUserOp(op, COST)
+        const results = ethers.utils.defaultAbiCoder.decode(['address', 'address', 'uint256', 'uint256'], context)
+
+        const expectedRate = bn(RATE.mul(10**tokenDecimals))
+        expect(results[2]).to.be.equal(expectedRate)
+        expect(results[3]).to.be.equal(baseFee)
+      })
+    }
+
+    context('when the token has 6 decimals', () => {
+      const tokenDecimals = 6
+
+      context('when the feed has 6 decimals', () => {
+        const feedDecimals = 6
+
+        itExpressTheRateCorrectly(tokenDecimals, feedDecimals)
+      })
+
+      context('when the feed has 18 decimals', () => {
+        const feedDecimals = 18
+
+        itExpressTheRateCorrectly(tokenDecimals, feedDecimals)
+      })
+
+      context('when the feed has 20 decimals', () => {
+        const feedDecimals = 20
+
+        itExpressTheRateCorrectly(tokenDecimals, feedDecimals)
+      })
+    })
+
+    context('when the token has 18 decimals', () => {
+      const tokenDecimals = 18
+
+      context('when the feed has 6 decimals', () => {
+        const feedDecimals = 6
+
+        itExpressTheRateCorrectly(tokenDecimals, feedDecimals)
+      })
+
+      context('when the feed has 18 decimals', () => {
+        const feedDecimals = 18
+
+        itExpressTheRateCorrectly(tokenDecimals, feedDecimals)
+      })
+
+      context('when the feed has 20 decimals', () => {
+        const feedDecimals = 20
+
+        itExpressTheRateCorrectly(tokenDecimals, feedDecimals)
+      })
+    })
+
+    context('when the token has 20 decimals', () => {
+      const tokenDecimals = 20
+
+      context('when the feed has 6 decimals', () => {
+        const feedDecimals = 6
+
+        itExpressTheRateCorrectly(tokenDecimals, feedDecimals)
+      })
+
+      context('when the feed has 18 decimals', () => {
+        const feedDecimals = 18
+
+        itExpressTheRateCorrectly(tokenDecimals, feedDecimals)
+      })
+
+      context('when the feed has 20 decimals', () => {
+        const feedDecimals = 20
+
+        itExpressTheRateCorrectly(tokenDecimals, feedDecimals)
+      })
+    })
+  })
+})

--- a/apps/contracts/test/Wallet.test.ts
+++ b/apps/contracts/test/Wallet.test.ts
@@ -410,7 +410,7 @@ describe('Wallet', () => {
                 // TODO: AUDIT! It requires having a prefund greater than zero which doesn't make sense for paymasters
 
                 beforeEach('deploy token', async () => {
-                  token = await deploy('TokenMock', ['USDC'])
+                  token = await deploy('TokenMock', ['DAI', 18])
                 })
 
                 context('when the guardian is approving tokens to the paymaster', () => {
@@ -609,7 +609,7 @@ describe('Wallet', () => {
         const fee = bn(100000), exchangeRate = fp(2)
 
         beforeEach('prepare paymaster data', async () => {
-          token = await deploy('TokenMock', ['USDC'])
+          token = await deploy('TokenMock', ['DAI', 18])
           feed = await deploy('PriceFeedMock', [18, exchangeRate])
         })
 
@@ -965,7 +965,7 @@ describe('Wallet', () => {
     const fee = bn(10), exchangeRate = fp(2), actualGasCost = fp(1)
 
     beforeEach('build context', async () => {
-      token = await deploy('TokenMock', ['USDC'])
+      token = await deploy('TokenMock', ['DAI', 18])
       const params = [other.address, token.address, exchangeRate, fee]
       contextData = ethers.utils.defaultAbiCoder.encode(['address', 'address', 'uint256', 'uint256'], params)
     })
@@ -1247,7 +1247,7 @@ describe('Wallet', () => {
 
       context('when the new implementation is not UUPS-compliant', () => {
         beforeEach('deploy non UUPS-compliant implementation', async () => {
-          newImplementation = await deploy('TokenMock', ['TKN'])
+          newImplementation = await deploy('TokenMock', ['TKN', 18])
         })
 
         it('reverts', async () => {


### PR DESCRIPTION
### MERGE AFTER #452 

The current implementation was not handling correctly the different decimals alternatives that could be returned by the Chainlink's price feeds.