### PR TITLE
Contracts: Fix paymaster validate interface

### DIFF
--- a/apps/contracts/contracts/entrypoint/EntryPoint.sol
+++ b/apps/contracts/contracts/entrypoint/EntryPoint.sol
@@ -105,7 +105,7 @@ contract EntryPoint is IEntryPoint, Staking {
     uint256 requiredPrefund = op.requiredPrefund();
     stake.value = stake.value.sub(requiredPrefund, "EntryPoint: Insufficient stake");
 
-    return IPaymaster(op.paymaster).validatePaymasterUserOp{ gas: validationGas }(op, requiredPrefund);
+    return IPaymaster(op.paymaster).validatePaymasterUserOp{ gas: validationGas }(op, op.requestId(), requiredPrefund);
   }
 
   function _executeOp(UserOperation calldata op, UserOpVerification memory verification)

--- a/apps/contracts/contracts/paymaster/IPaymaster.sol
+++ b/apps/contracts/contracts/paymaster/IPaymaster.sol
@@ -14,10 +14,11 @@ enum PostOpMode {
  * @dev Paymaster interface specified in https://eips.ethereum.org/EIPS/eip-4337
  */
 interface IPaymaster {
-  function validatePaymasterUserOp(UserOperation calldata op, uint256 cost)
-    external
-    view
-    returns (bytes memory context);
+  function validatePaymasterUserOp(
+    UserOperation calldata op,
+    bytes32 requestId,
+    uint256 maxCost
+  ) external view returns (bytes memory context);
 
   function postOp(
     PostOpMode mode,

--- a/apps/contracts/contracts/paymaster/Paymaster.sol
+++ b/apps/contracts/contracts/paymaster/Paymaster.sol
@@ -53,12 +53,11 @@ contract Paymaster is IPaymaster, UpgradeableACL {
    * @param cost amount to be paid to the entry point in wei
    * @return context including the payment conditions: sender, token, exchange rate, and fees
    */
-  function validatePaymasterUserOp(UserOperation calldata op, uint256 cost)
-    external
-    view
-    override
-    returns (bytes memory context)
-  {
+  function validatePaymasterUserOp(
+    UserOperation calldata op,
+    bytes32, /* requestId */
+    uint256 cost
+  ) external view override returns (bytes memory context) {
     require(isOwner(op.paymasterSigner()), "Paymaster: Invalid signature");
 
     PaymasterData memory paymasterData = op.decodePaymasterData();

--- a/apps/contracts/contracts/test/mocks/PaymasterMock.sol
+++ b/apps/contracts/contracts/test/mocks/PaymasterMock.sol
@@ -47,7 +47,11 @@ contract PaymasterMock is IPaymaster {
     entryPoint.withdrawStake(payable(address(this)));
   }
 
-  function validatePaymasterUserOp(UserOperation calldata, uint256) external view override returns (bytes memory) {
+  function validatePaymasterUserOp(
+    UserOperation calldata,
+    bytes32,
+    uint256
+  ) external view override returns (bytes memory) {
     require(!mockRevertVerification, "PAYMASTER_VERIFICATION_FAILED");
     return new bytes(0);
   }

--- a/apps/contracts/test/utils/models/wallet/Wallet.ts
+++ b/apps/contracts/test/utils/models/wallet/Wallet.ts
@@ -92,7 +92,7 @@ export default class Wallet {
   }
 
   async validatePaymasterUserOp(op: UserOp, maxCost: BigNumberish = 0): Promise<string> {
-    return this.instance.validatePaymasterUserOp(op, maxCost)
+    return this.instance.validatePaymasterUserOp(op, ZERO_BYTES32, maxCost)
   }
 
   async validateUserOp(op: UserOp, requestId = ZERO_BYTES32, prefundOrParams: BigNumberish | TxParams = 0, params: TxParams = {}): Promise<ContractTransaction> {


### PR DESCRIPTION
### MERGE AFTER #454 

The previous interface was not compliant with the standard, the `requestId` was not being passed from the EntryPoint.
However, it is not clear what the paymaster should do with it. Let's leave that door open for now.