### PR TITLE
Contracts: Make paymaster pay for post op costs

### DIFF
--- a/apps/contracts/contracts/entrypoint/EntryPoint.sol
+++ b/apps/contracts/contracts/entrypoint/EntryPoint.sol
@@ -114,13 +114,19 @@ contract EntryPoint is IEntryPoint, Staking {
   {
     uint256 preExecutionGas = gasleft();
     op.sender.callWithGas(op.callData, op.callGas, "EntryPoint: Execute failed");
-    uint256 totalGasUsed = verification.gasUsed + GasUsed.since(preExecutionGas);
-    totalGasCost = totalGasUsed * op.gasPrice();
-    uint256 refund = op.requiredPrefund().sub(totalGasCost, "EntryPoint: Insufficient refund");
 
-    // TODO: someone has to pay for this call
+    uint256 gasPrice = op.gasPrice();
+    uint256 requiredPrefund = op.requiredPrefund();
+    uint256 totalGasUsed = verification.gasUsed + GasUsed.since(preExecutionGas);
+    totalGasCost = totalGasUsed * gasPrice;
+    uint256 refund = requiredPrefund.sub(totalGasCost, "EntryPoint: Insufficient refund");
+
     if (op.hasPaymaster()) {
       IPaymaster(op.paymaster).postOp(PostOpMode.opSucceeded, verification.context, totalGasCost);
+      // Calculate gas cost again including post op and deduct this from the paymaster stake
+      totalGasUsed = verification.gasUsed + GasUsed.since(preExecutionGas);
+      totalGasCost = totalGasUsed * gasPrice;
+      refund = requiredPrefund.sub(totalGasCost, "EntryPoint: Insufficient refund");
       Stake storage stake = _getStake(op.paymaster);
       stake.value = stake.value + refund;
     } else {

--- a/apps/contracts/contracts/helpers/Calls.sol
+++ b/apps/contracts/contracts/helpers/Calls.sol
@@ -26,7 +26,7 @@ library Calls {
 
   /**
    * @dev Performs a Solidity function call using a low level `call` with `gas` gas.
-   * It the call succeeds, it returns the raw returned data.
+   * If the call succeeds, it returns the raw returned data.
    * If `target` reverts with a revert reason, it is bubbled up. Otherwise, it reverts with `errorMessage`.
    */
   function callWithGas(
@@ -42,7 +42,7 @@ library Calls {
 
   /**
    * @dev Performs a Solidity function call using a low level `call` with `gas` gas.
-   * It the call succeeds, it returns the raw returned data.
+   * If the call succeeds, it returns the raw returned data.
    * If `target` reverts with a revert reason, it is bubbled up. Otherwise, it reverts with `errorMessage`.
    */
   function callWithValue(


### PR DESCRIPTION
The idea for this PR is to make the paymaster pay for the post-op calls.
The problem is that paymasters won't know how much it will cost, so ideally it should consider that as part of their fee model in advance.