### PR TITLE
Optimisation for creating, encrypting, and decrypting signing keys on mobile

### DIFF
--- a/apps/mobile/.prettierignore
+++ b/apps/mobile/.prettierignore
@@ -7,3 +7,4 @@ Gemfile
 Gemfile.lock
 android
 ios
+*.patch

--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -1,4 +1,4 @@
-import './src/utils/shims';
+import './shims';
 
 import React, {ReactNode, useState} from 'react';
 import {ActivityIndicator, Button} from 'react-native';
@@ -11,8 +11,7 @@ import {
   useColorScheme,
   View,
 } from 'react-native';
-// import {wallet} from '@stackupfinance/walletjs';
-import {ethers} from 'ethers';
+import {wallet} from '@stackupfinance/walletjs';
 
 const Section: React.FC<{
   children?: ReactNode;
@@ -41,30 +40,30 @@ const App = () => {
     // NOTE: crypto functions should be wrapped in a setTimeout
     // to prevent blocking of the UI.
     setTimeout(async () => {
-      // const _w = await wallet.proxy.initEncryptedIdentity('password', 'salt');
-      // setWallet(_w);
-
-      // const _s1 = await wallet.proxy.decryptSigner(_w, 'password', 'salt');
-      // setSigner1(_s1);
-
-      // const _rs = await wallet.proxy.reencryptSigner(
-      //   _w,
-      //   'password',
-      //   'newPassword',
-      //   'salt',
-      // );
-      // setReencryptSigner(_rs);
-      // const _s2 = await wallet.proxy.decryptSigner(
-      //   {encryptedSigner: _rs},
-      //   'newPassword',
-      //   'salt',
-      // );
-      // setSigner2(_s2);
-
-      // const _s3 = await wallet.proxy.decryptSigner(_w, 'wrongPassword', 'salt');
-      // setSigner3(_s3);
-      const _w = ethers.Wallet.createRandom();
+      const _w = await wallet.proxy.initEncryptedIdentity('password', 'salt');
       setWallet(_w);
+
+      const _s1 = await wallet.proxy.decryptSigner(_w, 'password', 'salt');
+      setSigner1(_s1);
+
+      const _rs = await wallet.proxy.reencryptSigner(
+        _w,
+        'password',
+        'newPassword',
+        'salt',
+      );
+      setReencryptSigner(_rs);
+
+      const _s2 = await wallet.proxy.decryptSigner(
+        {encryptedSigner: _rs},
+        'newPassword',
+        'salt',
+      );
+      setSigner2(_s2);
+
+      const _s3 = await wallet.proxy.decryptSigner(_w, 'wrongPassword', 'salt');
+      setSigner3(_s3);
+
       setLoading(false);
     });
   };
@@ -74,11 +73,7 @@ const App = () => {
       <StatusBar barStyle={isDarkMode ? 'light-content' : 'dark-content'} />
       <ScrollView contentInsetAdjustmentBehavior="automatic">
         <View>
-          <Section title="New wallet:">
-            <Text style={[styles.sectionBody]}>{JSON.stringify(w)}</Text>
-          </Section>
-
-          {/* <Section title="walletjs: initEncryptedIdentity()">
+          <Section title="walletjs: initEncryptedIdentity()">
             <Text style={[styles.sectionBody]}>{JSON.stringify(w)}</Text>
           </Section>
 
@@ -88,9 +83,9 @@ const App = () => {
 
           <Section title="walletjs: reencryptSigner()">
             <Text style={[styles.sectionBody]}>{rs}</Text>
-          </Section> */}
+          </Section>
 
-          {/* <Section title="walletjs: checks">
+          <Section title="walletjs: checks">
             {w && (
               <>
                 <Text style={[styles.sectionBody]}>
@@ -118,7 +113,7 @@ const App = () => {
                 </Text>
               </>
             )}
-          </Section> */}
+          </Section>
 
           {loading && <ActivityIndicator />}
 

--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -1,6 +1,7 @@
 import './src/utils/shims';
 
-import React, {ReactNode, useState, useEffect} from 'react';
+import React, {ReactNode, useState} from 'react';
+import {ActivityIndicator, Button} from 'react-native';
 import {
   SafeAreaView,
   ScrollView,
@@ -10,7 +11,8 @@ import {
   useColorScheme,
   View,
 } from 'react-native';
-import {wallet} from '@stackupfinance/walletjs';
+// import {wallet} from '@stackupfinance/walletjs';
+import {ethers} from 'ethers';
 
 const Section: React.FC<{
   children?: ReactNode;
@@ -31,40 +33,52 @@ const App = () => {
   const [rs, setReencryptSigner]: [any, any] = useState();
   const [s2, setSigner2]: [any, any] = useState();
   const [s3, setSigner3]: [any, any] = useState();
+  const [loading, setLoading] = useState(false);
 
-  useEffect(() => {
-    (async () => {
-      const _w = await wallet.proxy.initEncryptedIdentity('password', 'salt');
+  const checkWalletJs = async () => {
+    setLoading(true);
+
+    // NOTE: crypto functions should be wrapped in a setTimeout
+    // to prevent blocking of the UI.
+    setTimeout(async () => {
+      // const _w = await wallet.proxy.initEncryptedIdentity('password', 'salt');
+      // setWallet(_w);
+
+      // const _s1 = await wallet.proxy.decryptSigner(_w, 'password', 'salt');
+      // setSigner1(_s1);
+
+      // const _rs = await wallet.proxy.reencryptSigner(
+      //   _w,
+      //   'password',
+      //   'newPassword',
+      //   'salt',
+      // );
+      // setReencryptSigner(_rs);
+      // const _s2 = await wallet.proxy.decryptSigner(
+      //   {encryptedSigner: _rs},
+      //   'newPassword',
+      //   'salt',
+      // );
+      // setSigner2(_s2);
+
+      // const _s3 = await wallet.proxy.decryptSigner(_w, 'wrongPassword', 'salt');
+      // setSigner3(_s3);
+      const _w = ethers.Wallet.createRandom();
       setWallet(_w);
-
-      const _s1 = await wallet.proxy.decryptSigner(_w, 'password', 'salt');
-      setSigner1(_s1);
-
-      const _rs = await wallet.proxy.reencryptSigner(
-        _w,
-        'password',
-        'newPassword',
-        'salt',
-      );
-      setReencryptSigner(_rs);
-      const _s2 = await wallet.proxy.decryptSigner(
-        {encryptedSigner: _rs},
-        'newPassword',
-        'salt',
-      );
-      setSigner2(_s2);
-
-      const _s3 = await wallet.proxy.decryptSigner(_w, 'wrongPassword', 'salt');
-      setSigner3(_s3);
-    })();
-  }, []);
+      setLoading(false);
+    });
+  };
 
   return (
     <SafeAreaView>
       <StatusBar barStyle={isDarkMode ? 'light-content' : 'dark-content'} />
       <ScrollView contentInsetAdjustmentBehavior="automatic">
         <View>
-          <Section title="walletjs: initEncryptedIdentity()">
+          <Section title="New wallet:">
+            <Text style={[styles.sectionBody]}>{JSON.stringify(w)}</Text>
+          </Section>
+
+          {/* <Section title="walletjs: initEncryptedIdentity()">
             <Text style={[styles.sectionBody]}>{JSON.stringify(w)}</Text>
           </Section>
 
@@ -74,32 +88,41 @@ const App = () => {
 
           <Section title="walletjs: reencryptSigner()">
             <Text style={[styles.sectionBody]}>{rs}</Text>
-          </Section>
+          </Section> */}
 
-          <Section title="walletjs: checks">
-            <Text style={[styles.sectionBody]}>
-              wallet.initOwner === signer.address:{' '}
-              {(w?.initOwner === s1?.address).toString()}
-              {'\n'}
-            </Text>
+          {/* <Section title="walletjs: checks">
+            {w && (
+              <>
+                <Text style={[styles.sectionBody]}>
+                  wallet.initOwner === signer.address:{' '}
+                  {(w?.initOwner === s1?.address).toString()}
+                  {'\n'}
+                </Text>
 
-            <Text style={[styles.sectionBody]}>
-              reencryptSigner decrypts to same signer:{' '}
-              {(JSON.stringify(s1) === JSON.stringify(s2)).toString()}
-              {'\n'}
-            </Text>
+                <Text style={[styles.sectionBody]}>
+                  reencryptSigner decrypts to same signer:{' '}
+                  {(JSON.stringify(s1) === JSON.stringify(s2)).toString()}
+                  {'\n'}
+                </Text>
 
-            <Text style={[styles.sectionBody]}>
-              wallet.encryptedSigner !== reencryptSigner:{' '}
-              {(w?.encryptedSigner !== rs).toString()}
-              {'\n'}
-            </Text>
+                <Text style={[styles.sectionBody]}>
+                  wallet.encryptedSigner !== reencryptSigner:{' '}
+                  {(w?.encryptedSigner !== rs).toString()}
+                  {'\n'}
+                </Text>
 
-            <Text style={[styles.sectionBody]}>
-              wrong password returns undefined: {(s3 === undefined).toString()}
-              {'\n'}
-            </Text>
-          </Section>
+                <Text style={[styles.sectionBody]}>
+                  wrong password returns undefined:{' '}
+                  {(s3 === undefined).toString()}
+                  {'\n'}
+                </Text>
+              </>
+            )}
+          </Section> */}
+
+          {loading && <ActivityIndicator />}
+
+          <Button title="Generate" onPress={checkWalletJs} />
         </View>
       </ScrollView>
     </SafeAreaView>

--- a/apps/mobile/global.d.ts
+++ b/apps/mobile/global.d.ts
@@ -1,0 +1,3 @@
+declare module globalThis {
+  function scrypt(passwd, salt, N, r, p, size): Promise<Uint8Array>;
+}

--- a/apps/mobile/ios/Podfile.lock
+++ b/apps/mobile/ios/Podfile.lock
@@ -282,6 +282,8 @@ PODS:
   - React-jsinspector (0.68.1)
   - React-logger (0.68.1):
     - glog
+  - react-native-fast-crypto (2.2.0):
+    - React
   - react-native-get-random-values (1.7.2):
     - React-Core
   - React-perflogger (0.68.1)
@@ -397,6 +399,7 @@ DEPENDENCIES:
   - React-jsiexecutor (from `../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
+  - react-native-fast-crypto (from `../node_modules/react-native-fast-crypto`)
   - react-native-get-random-values (from `../../../node_modules/react-native-get-random-values`)
   - React-perflogger (from `../node_modules/react-native/ReactCommon/reactperflogger`)
   - React-RCTActionSheet (from `../node_modules/react-native/Libraries/ActionSheetIOS`)
@@ -467,6 +470,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/jsinspector"
   React-logger:
     :path: "../node_modules/react-native/ReactCommon/logger"
+  react-native-fast-crypto:
+    :path: "../node_modules/react-native-fast-crypto"
   react-native-get-random-values:
     :path: "../../../node_modules/react-native-get-random-values"
   React-perflogger:
@@ -528,6 +533,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 4a4bae5671b064a2248a690cf75957669489d08c
   React-jsinspector: 218a2503198ff28a085f8e16622a8d8f507c8019
   React-logger: f79dd3cc0f9b44f5611c6c7862badd891a862cf8
+  react-native-fast-crypto: 5943c42466b86ad70be60d3a5f64bd22251e5d9e
   react-native-get-random-values: 30b3f74ca34e30e2e480de48e4add2706a40ac8f
   React-perflogger: 30ab8d6db10e175626069e742eead3ebe8f24fd5
   React-RCTActionSheet: 4b45da334a175b24dabe75f856b98fed3dfd6201

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -16,8 +16,11 @@
     "@ethersproject/shims": "^5.6.0",
     "@stackupfinance/walletjs": "1.0.0",
     "ethers": "^5.6.4",
+    "patch-package": "^6.4.7",
+    "postinstall-postinstall": "^2.1.0",
     "react": "17.0.2",
     "react-native": "0.68.1",
+    "react-native-fast-crypto": "^2.2.0",
     "react-native-get-random-values": "^1.7.2"
   },
   "devDependencies": {

--- a/apps/mobile/patches/react-native-fast-crypto+2.2.0.patch
+++ b/apps/mobile/patches/react-native-fast-crypto+2.2.0.patch
@@ -1,0 +1,17 @@
+diff --git a/node_modules/react-native-fast-crypto/index.js b/node_modules/react-native-fast-crypto/index.ts
+similarity index 100%
+rename from node_modules/react-native-fast-crypto/index.js
+rename to node_modules/react-native-fast-crypto/index.ts
+diff --git a/node_modules/react-native-fast-crypto/package.json b/node_modules/react-native-fast-crypto/package.json
+index 86ba5fc..4c6631d 100644
+--- a/node_modules/react-native-fast-crypto/package.json
++++ b/node_modules/react-native-fast-crypto/package.json
+@@ -19,7 +19,7 @@
+     "Paul Puey <paul@edge.app>",
+     "William Swanson <william@edge.app>"
+   ],
+-  "main": "index.js",
++  "main": "index.ts",
+   "files": [
+     "/android/build.gradle",
+     "/android/jni/*",

--- a/apps/mobile/shims.ts
+++ b/apps/mobile/shims.ts
@@ -1,4 +1,8 @@
 import 'react-native-get-random-values';
 import '@ethersproject/shims';
+
+import {scrypt} from 'react-native-fast-crypto';
+global.scrypt = scrypt;
+
 import {Buffer} from 'buffer';
 global.Buffer = global.Buffer || Buffer;

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "node": "^14"
   },
   "scripts": {
+    "postinstall": "yarn workspace @stackupfinance/mobile run patch-package --exclude 'nothing'",
     "install:ios": "cd apps/mobile/ios && pod install && cd - || cd -",
     "test": "lerna run test --stream",
     "lint": "lerna run lint --stream",
@@ -33,7 +34,8 @@
     ],
     "nohoist": [
       "**/react-native",
-      "**/react-native/**"
+      "**/react-native/**",
+      "**/react-native-fast-crypto"
     ]
   },
   "devDependencies": {

--- a/packages/walletjs/lib/wallet/proxy.js
+++ b/packages/walletjs/lib/wallet/proxy.js
@@ -11,6 +11,8 @@ const walletProxy = require("../contracts/walletProxy");
 const userOperation = require("../constants/userOperations");
 const encodeFunctionData = require("./encodeFunctionData");
 
+const _scryptFn = global.scrypt ?? scrypt.scrypt;
+
 const _getInitCode = (
   initImplementation,
   initEntryPoint,
@@ -47,7 +49,7 @@ const generatePasswordKey = async (password, salt) => {
   const saltBuffer = new buffer.SlowBuffer(
     salt.toLowerCase().normalize("NFKC")
   );
-  return scrypt.scrypt(passwordBuffer, saltBuffer, N, r, p, dkLen);
+  return _scryptFn(passwordBuffer, saltBuffer, N, r, p, dkLen);
 };
 
 module.exports.decryptSigner = async (wallet, password, salt) => {
@@ -94,7 +96,7 @@ module.exports.reencryptSigner = async (
 };
 
 module.exports.initEncryptedIdentity = async (password, salt, opts = {}) => {
-  const signer = ethers.Wallet.createRandom();
+  const signer = new ethers.Wallet(ethers.utils.randomBytes(32));
 
   const initImplementation = Wallet.address;
   const initEntryPoint = EntryPoint.address;

--- a/packages/walletjs/lib/wallet/proxy.js
+++ b/packages/walletjs/lib/wallet/proxy.js
@@ -11,7 +11,14 @@ const walletProxy = require("../contracts/walletProxy");
 const userOperation = require("../constants/userOperations");
 const encodeFunctionData = require("./encodeFunctionData");
 
-const _scryptFn = global.scrypt ?? scrypt.scrypt;
+let _scryptFn;
+// eslint-disable-next-line no-undef
+if (typeof navigator !== "undefined" && navigator.product === "ReactNative") {
+  // Use a shim for scrypt if in React Native environment.
+  _scryptFn = global.scrypt;
+} else {
+  _scryptFn = scrypt.scrypt;
+}
 
 const _getInitCode = (
   initImplementation,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7374,7 +7374,7 @@ buffer-xor@^2.0.1:
   dependencies:
     safe-buffer "^5.1.1"
 
-buffer@^5.0.5, buffer@^5.2.1, buffer@^5.5.0, buffer@^5.6.0:
+buffer@^5.0.5, buffer@^5.0.8, buffer@^5.2.1, buffer@^5.5.0, buffer@^5.6.0:
   version "5.7.1"
   resolved "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz"
   integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
@@ -16383,9 +16383,9 @@ patch-package@6.2.2:
     slash "^2.0.0"
     tmp "^0.0.33"
 
-patch-package@^6.2.2:
+patch-package@^6.2.2, patch-package@^6.4.7:
   version "6.4.7"
-  resolved "https://registry.npmjs.org/patch-package/-/patch-package-6.4.7.tgz"
+  resolved "https://registry.yarnpkg.com/patch-package/-/patch-package-6.4.7.tgz#2282d53c397909a0d9ef92dae3fdeb558382b148"
   integrity sha512-S0vh/ZEafZ17hbhgqdnpunKDfzHQibQizx9g8yEf5dcVk3KOflOfdufRXQX8CSEkyOQwuM/bNz1GwKvFj54kaQ==
   dependencies:
     "@yarnpkg/lockfile" "^1.1.0"
@@ -16601,7 +16601,7 @@ postcss@8.4.5:
 
 postinstall-postinstall@^2.1.0:
   version "2.1.0"
-  resolved "https://registry.npmjs.org/postinstall-postinstall/-/postinstall-postinstall-2.1.0.tgz"
+  resolved "https://registry.yarnpkg.com/postinstall-postinstall/-/postinstall-postinstall-2.1.0.tgz#4f7f77441ef539d1512c40bd04c71b06a4704ca3"
   integrity sha512-7hQX6ZlZXIoRiWNrbMQaLzUUfH+sSx39u8EJ9HYuDc1kLo9IXKWjM5RSquZN1ad5GnH8CGFM78fsAAQi3OKEEQ==
 
 precond@0.2:
@@ -17111,6 +17111,14 @@ react-native-codegen@^0.0.13:
     flow-parser "^0.121.0"
     jscodeshift "^0.13.1"
     nullthrows "^1.1.1"
+
+react-native-fast-crypto@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/react-native-fast-crypto/-/react-native-fast-crypto-2.2.0.tgz#062014a563ef34af30e1969ae4ae4b5cd6ab9e44"
+  integrity sha512-JXQmnXGH3HpJYZrBsR7sL6cO/W3k1pHqTYbwnwTsJ8VUYXIsIEf1T0nMk6Z+XkQNI8RIQOeWJ9AuZLai4onHZg==
+  dependencies:
+    buffer "^5.0.8"
+    rfc4648 "^1.0.0"
 
 react-native-get-random-values@^1.7.2:
   version "1.7.2"
@@ -17759,6 +17767,11 @@ reusify@^1.0.4:
   version "1.0.4"
   resolved "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+
+rfc4648@^1.0.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/rfc4648/-/rfc4648-1.5.1.tgz#b0b16756e33d9de8c0c7833e94b28e627ec372a4"
+  integrity sha512-60e/YWs2/D3MV1ErdjhJHcmlgnyLUiG4X/14dgsfm9/zmCWLN16xI6YqJYSCd/OANM7bUNzJqPY5B8/02S9Ibw==
 
 rimraf@2.6.3, rimraf@~2.6.2:
   version "2.6.3"


### PR DESCRIPTION
The current implementation was creating, encrypting, and decrypting signing keys on mobile (android specifically) extremely slow. The biggest bottle necks were coming from 2 key derivation functions:

1. `ethers.Wallet.createRandom()` creates a seed phrase that calls `pbkdf2` under the hood. It then uses the default path to derive the signing key. However our wallet just requires a single signing key rather than a seed phrase. In this case we can bypass calling `pbkdf2` entirely by calling `new ethers.Wallet(ethers.utils.randomBytes(32))` instead.
2. We use `scrypt` as a KDF in the encryption and decryption process. There's no way to bypass this call so instead we need to rely on a native (rather than JS) implementation. In this case we swap out the function for a native version implemented by https://github.com/EdgeApp/react-native-fast-crypto.

The result is a reduction from more than 1 minute to 1 second.